### PR TITLE
Add --iface command line switch to specify network interface.

### DIFF
--- a/pypwrctrl/main.py
+++ b/pypwrctrl/main.py
@@ -142,6 +142,7 @@ def save(master, args):
     parser.set(GENERAL_SECTION, 'password', master.password)
     parser.set(GENERAL_SECTION, 'pin', str(master.pin))
     parser.set(GENERAL_SECTION, 'pout', str(master.pout))
+    parser.set(GENERAL_SECTION, 'iface', str(master.iface))
 
     for device in master.devices:
         parser.add_section(device.address)
@@ -232,6 +233,8 @@ def main():
             help="Port to use for receiving (sending from device perspective, default from config or 75)", metavar="PORT")
     parser.add_option("-o", "--out", dest="pout", default=fallback_pout, type="int",
             help="Port to use for sending (sending from device perspective, default from config or 77)", metavar="PORT")
+    parser.add_option("-I", "--iface", dest="iface", default=None,
+                      help="Network interface", metavar="IFACE")
 
     (options, args) = parser.parse_args()
 
@@ -258,7 +261,8 @@ def main():
         print("Unknown command, sorry")
         return 1
 
-    master = PlugMaster(options.pin, options.pout, options.user, options.password)
+    master = PlugMaster(options.pin, options.pout, options.user,
+                        options.password, options.iface)
 
     # do we have to load the configured devices?
     if not options.discover and command != 'save':

--- a/pypwrctrl/main.py
+++ b/pypwrctrl/main.py
@@ -207,8 +207,8 @@ def main():
 
     fallback_user = config.get(GENERAL_SECTION, 'user', fallback='admin')
     fallback_password = config.get(GENERAL_SECTION, 'password', fallback='anel')
-    fallback_pin = config.getint(GENERAL_SECTION, 'pin', fallback=75)
-    fallback_pout = config.getint(GENERAL_SECTION, 'pout', fallback=77)
+    fallback_pin = config.getint(GENERAL_SECTION, 'pin', fallback=77)
+    fallback_pout = config.getint(GENERAL_SECTION, 'pout', fallback=75)
 
     # option parsing
 
@@ -229,10 +229,14 @@ def main():
     parser.add_option("-p", "--password", dest="password", default=fallback_password,
             help="Password on device (default from config or  'anel')", metavar="PASSWORD")
 
-    parser.add_option("-i", "--in", dest="pin", default=fallback_pin, type="int",
-            help="Port to use for receiving (sending from device perspective, default from config or 75)", metavar="PORT")
-    parser.add_option("-o", "--out", dest="pout", default=fallback_pout, type="int",
-            help="Port to use for sending (sending from device perspective, default from config or 77)", metavar="PORT")
+    parser.add_option("-i", "--in", dest="pin", default=fallback_pin,
+                      type="int", help="Port to use for receiving "
+                      "(sending from device perspective, default from config "
+                      "or 77)", metavar="PORT")
+    parser.add_option("-o", "--out", dest="pout", default=fallback_pout,
+                      type="int", help="Port to use for sending (sending from "
+                      "device perspective, default from config or 75)",
+                      metavar="PORT")
     parser.add_option("-I", "--iface", dest="iface", default=None,
                       help="Network interface", metavar="IFACE")
 

--- a/pypwrctrl/pypwrctrl.py
+++ b/pypwrctrl/pypwrctrl.py
@@ -92,19 +92,27 @@ class PlugDevice:
 
 class PlugMaster:
 
-    def __init__(self, pin=77, pout=75, user="admin", password="anel"):
+    def __init__(self, pin=77, pout=75, user="admin", password="anel",
+                 iface=None):
         self.pin = pin
         self.pout = pout
         self.user = user
         self.password = password
 
+        self.iface = iface
         self.devices = []
 
         self.sin = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        if self.iface is not None:
+                self.sin.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE,
+                                    bytes(iface, 'UTF-8'))
         self.sin.bind(('0.0.0.0', pin))
 
         self.sout = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sout.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        if self.iface is not None:
+                self.sout.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE,
+                                     bytes(iface, 'UTF-8'))
 
     def search_device(self, needle):
         found = set()


### PR DESCRIPTION
When using multiple network interfaces multicast traffic might not be
sent to all networks or maybe should not be sent to all networks. Add a
command line switch to choose a network interface.
That is probably Linux specific and requires root privileges.

Signed-off-by: Henning Schild henning@hennsch.de
